### PR TITLE
Change to use virtualenv as default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
   enable-pep582:
     description: "Enable PEP 582 package loading globally."
-    default: "true"
+    default: "false"
     required: false
   cache:
     description: "Cache PDM installation."


### PR DESCRIPTION
As mentioned in the website, PEP 582 has become an opt-in feature in PDM.  
My recommendation is to use the same default in the actions.