### PR TITLE
Update utils.ts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ export async function findPythonVersion(version: string, architecture: string, a
     core.info(
       `Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
     );
-    return installed.resolvedPythonVersion;
+    return `pypy-${installed.resolvedPythonVersion}`;
   } else {
     const installed = await useCpythonVersion(
       version,


### PR DESCRIPTION
Add `pypy-` prefix to version used for cache key when appropriate.

Right now, since GitHub actions is using the same version of python 3.8 and python 3.9 between CPython and PyPy, and since the current cache keys only account for the version number (not any additional detail), you get cache hits between the two different interpreters.

It seems to me the change here only affects the key used for caching, so I think it should be safe. Apologies if I'm overlooking something!