### PR TITLE
set pdm `version: 2.9.1` in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ steps:
       with:
         python-version: 3.9              # Version range or exact version of a Python version to use, the same as actions/setup-python
         architecture: x64                # The target architecture (x86, x64) of the Python interpreter. the same as actions/setup-python
-        version: 2.7.4                   # The version of PDM to install. Leave it as empty to use the latest version from PyPI, or 'head' to use the latest version from GitHub
+        version: 2.9.1                   # The version of PDM to install. Leave it as empty to use the latest version from PyPI, or 'head' to use the latest version from GitHub
         prerelease: false                # Allow prerelease versions of PDM to be installed
         enable-pep582: false             # Enable PEP 582 package loading globally
         allow-python-prereleases: false  # Allow prerelease versions of Python to be installed. For example if only 3.12-dev is available, 3.12 will fallback to 3.12-dev


### PR DESCRIPTION
Users tend to copy+paste from the README into their actions, so it's nice to have the latest version pinned in the example usage.