### PR TITLE
Explicitly exit the process to not wait for hanging promises

### DIFF
--- a/dist/setup-pdm.js
+++ b/dist/setup-pdm.js
@@ -91128,6 +91128,7 @@ async function run() {
   } catch (error2) {
     core8.setFailed(error2.message);
   }
+  import_node_process4.default.exit();
 }
 run();
 /*! Bundled license information:

--- a/src/setup-pdm.ts
+++ b/src/setup-pdm.ts
@@ -67,6 +67,9 @@ async function run(): Promise<void> {
   catch (error: any) {
     core.setFailed(error.message)
   }
+  // Explicit process.exit() to not wait for hanging promises,
+  // see https://github.com/actions/setup-node/issues/878
+  process.exit()
 }
 
 run()


### PR DESCRIPTION
As with other actions like setup-node, I'm seeing 2-4 minute delays in post cache actions lately. Apparently this is because of a change in node behavior: https://github.com/ruby/setup-ruby/issues/543#issuecomment-1793608370

The fix, as with other actions, is to explicitly exit so as not to wait for hanging promises.