### PR TITLE
move process.exit() to cache-save.ts

### DIFF
--- a/dist/cache-save.js
+++ b/dist/cache-save.js
@@ -74843,6 +74843,7 @@ async function run() {
     const err = error;
     core.setFailed(err.message);
   }
+  process.exit();
 }
 async function saveCache2() {
   const cachePaths = JSON.parse(core.getState("cache-paths"));

--- a/dist/setup-pdm.js
+++ b/dist/setup-pdm.js
@@ -91128,7 +91128,6 @@ async function run() {
   } catch (error2) {
     core8.setFailed(error2.message);
   }
-  import_node_process4.default.exit();
 }
 run();
 /*! Bundled license information:

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -12,6 +12,9 @@ async function run() {
     const err = error as Error
     core.setFailed(err.message)
   }
+  // Explicit process.exit() to not wait for hanging promises,
+  // see https://github.com/actions/setup-node/issues/878
+  process.exit()
 }
 
 async function saveCache() {

--- a/src/setup-pdm.ts
+++ b/src/setup-pdm.ts
@@ -67,9 +67,6 @@ async function run(): Promise<void> {
   catch (error: any) {
     core.setFailed(error.message)
   }
-  // Explicit process.exit() to not wait for hanging promises,
-  // see https://github.com/actions/setup-node/issues/878
-  process.exit()
 }
 
 run()


### PR DESCRIPTION
Moving the fix to cache-save since the hang we're trying to prevent comes in the post-action.

This is to fix the delay caused by a change in node defaults: see  https://github.com/ruby/setup-ruby/issues/543#issuecomment-1793608370

The fix is to explicitly exit so as not to wait for hanging promises.