### PR TITLE
[New Feature]: Distinguish architectures of caches

### DIFF
--- a/dist/setup-pdm.js
+++ b/dist/setup-pdm.js
@@ -91048,8 +91048,8 @@ var cache3 = __toESM(require_cache2());
 var import_glob = __toESM(require_glob2());
 async function calculateCacheKeys(pythonVersion, cacheDependencyPath) {
   const hash = await (0, import_glob.hashFiles)(cacheDependencyPath);
-  const primaryKey = `setup-pdm-${import_node_process3.default.env.RUNNER_OS}-python-${pythonVersion}-${hash}`;
-  const restoreKey = `setup-pdm-${import_node_process3.default.env.RUNNER_OS}-python-${pythonVersion}-`;
+  const primaryKey = `setup-pdm-${import_node_process3.default.env.RUNNER_OS}-${import_node_process3.default.env.RUNNER_ARCH}-python-${pythonVersion}-${hash}`;
+  const restoreKey = `setup-pdm-${import_node_process3.default.env.RUNNER_OS}-${import_node_process3.default.env.RUNNER_ARCH}-python-${pythonVersion}-`;
   return { primaryKey, restoreKeys: [restoreKey] };
 }
 async function cacheDependencies(pdmBin, pythonVersion) {

--- a/src/caches.ts
+++ b/src/caches.ts
@@ -7,8 +7,8 @@ import { getOutput } from './utils'
 
 async function calculateCacheKeys(pythonVersion: string, cacheDependencyPath: string): Promise<{ primaryKey: string, restoreKeys: string[] }> {
   const hash = await hashFiles(cacheDependencyPath)
-  const primaryKey = `setup-pdm-${process.env.RUNNER_OS}-python-${pythonVersion}-${hash}`
-  const restoreKey = `setup-pdm-${process.env.RUNNER_OS}-python-${pythonVersion}-`
+  const primaryKey = `setup-pdm-${process.env.RUNNER_OS}-${process.env.RUNNER_ARCH}-python-${pythonVersion}-${hash}`
+  const restoreKey = `setup-pdm-${process.env.RUNNER_OS}-${process.env.RUNNER_ARCH}-python-${pythonVersion}-`
   return { primaryKey, restoreKeys: [restoreKey] }
 }
 


### PR DESCRIPTION
## ❓ What's changed

- Modify `src/caches.ts`, add an "architecture section" to variables `primaryKey` and `restoreKey`
- Re-generate `dist/setup-pdm.js` with `pnpm run build`

## Additional information

- Resolve #56 

> [!NOTE]
>
> This pull request will change behaviors of this _GitHub Action_. It's verified with [`nektos.act`](https://github.com/nektos/act) on Windows `amd64` host, Docker Desktop v4.31.1 and [`catthehacker/ubuntu:act-latest`](https://github.com/catthehacker/docker_images).

> [!CAUTION]
>
> I'm new to TypeScript and `pnpm`, so please check my pull request carefully!